### PR TITLE
Add code linter github action, a script that helps format the code base and formatting of the codebase using that script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,182 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -179,4 +179,5 @@ WhitespaceSensitiveMacros:
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
 ...
-
+Language: Proto
+BasedOnStyle: Google

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-name: Buzzer CI
+name: Buzzer-CI
 run-name: Running Buzzer tests.
-on: [push]
+on: [push, pull_request]
 jobs:
   Buzzer-CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         clang-format-version: '13'
         check-path: 'src'
-        fallback-style: 'Mozilla'
+        fallback-style: 'Google'
   go-linter:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Buzzer Linter
+run-name: Checking code format.
+on: [pull_request, push]
+jobs:
+  clang-linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '13'
+        check-path: 'src'
+        fallback-style: 'Mozilla'
+  go-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Go Lint
+        uses: Jerome1337/gofmt-action@v1.0.5
+  bazel-buildifier:
+    name: Run buildifier check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run buildifier
+      uses: jbajic/buildifier@v1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,8 +9,11 @@ http_archive(
         "https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip",
     ],
 )
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
+
 go_register_toolchains(version = "1.20.3")
 
 # Porotobuf library.
@@ -22,19 +25,23 @@ http_archive(
         "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
     ],
 )
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
 protobuf_deps()
 
 # Absl
 http_archive(
-  name = "com_google_absl",
-  urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.2.zip"],
-  sha256 = "2d40102022a01c6f3dddd23ec9ddafff49697a2e4bd09af68bccb74d26ecf64a",
-  strip_prefix = "abseil-cpp-20230125.2",
+    name = "com_google_absl",
+    sha256 = "2d40102022a01c6f3dddd23ec9ddafff49697a2e4bd09af68bccb74d26ecf64a",
+    strip_prefix = "abseil-cpp-20230125.2",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.2.zip"],
 )
 
 # Protobuf source code.
@@ -43,7 +50,7 @@ http_archive(
     sha256 = "1ff680568f8e537bb4be9813bac0c1d87848d5be9d000ebe30f0bc2d7aabe045",
     strip_prefix = "protobuf-22.2",
     urls = [
-		"https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protobuf-22.2.tar.gz"
+        "https://github.com/protocolbuffers/protobuf/releases/download/v22.2/protobuf-22.2.tar.gz",
     ],
 )
 
@@ -54,10 +61,13 @@ http_archive(
     strip_prefix = "bazel-gazelle-0.30.0",
     url = "https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.30.0.zip",
 )
+
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
 gazelle_dependencies()
 
 load("@bazel_gazelle//:deps.bzl", "go_repository")
+
 go_repository(
     name = "com_github_google_safehtml",
     build_file_proto_mode = "disable_global",

--- a/ebpf_ffi/ffi.h
+++ b/ebpf_ffi/ffi.h
@@ -17,21 +17,22 @@
 #ifndef EBPF_FUZZER_EBPF_FFI_FFI_H_
 #define EBPF_FUZZER_EBPF_FFI_FFI_H_
 
+#include <linux/bpf.h>
+
 #include <cstddef>
 #include <cstdint>
-#include <linux/bpf.h>
 
 extern "C" {
 // This struct is used to return the serialized proto containing the verify
 // results.
 struct bpf_result {
-  char* serialized_proto;
+  char *serialized_proto;
   size_t size;
 };
 
 // Loads a bpf program specified by |prog_buff| with |size| and returns struct
 // with a serialized ValidationResult proto.
-struct bpf_result load_bpf_program(void* prog_buff, size_t size,
+struct bpf_result load_bpf_program(void *prog_buff, size_t size,
                                    int coverage_enabled,
                                    uint64_t coverage_size);
 
@@ -47,6 +48,6 @@ struct bpf_result execute_bpf_program(int prog_fd, int map_fd, int map_count);
 struct coverage_data {
   int fd;
   uint64_t coverage_size;
-  uint64_t* coverage_buffer;
+  uint64_t *coverage_buffer;
 };
 #endif  // SECURITY_ISE_CLOUD_PROJECTS_EBPF_FUZZER_EBPF_FFI_FFI_H_

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,2 @@
+#/bin/sh
+find . -iname *.h -o -iname *.cc -o -iname *.proto | xargs clang-format -i

--- a/format.sh
+++ b/format.sh
@@ -1,2 +1,12 @@
 #/bin/sh
+
+# Usage: ./format.sh
+# Make sure to have clang-format, gofmt and buildifier installed.
+# For debian/ubuntu distros you can install clang-format with `sudo apt install clang-format`
+# Go format is installed with golang: `sudo apt install golang`
+# For buildifier follow these instructions: 
+#  https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#setup
+# Also for buildifier make sure to setup the correct GOPATH variable.
 find . -iname *.h -o -iname *.cc -o -iname *.proto | xargs clang-format -i
+gofmt -w -s .
+$GOPATH/bin/buildifier -r .

--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@
 package main
 
 import (
-	"log"
 	"flag"
+	"log"
 
 	"buzzer/pkg/metrics/metrics"
 	"buzzer/pkg/units/units"

--- a/pkg/ebpf/BUILD
+++ b/pkg/ebpf/BUILD
@@ -33,13 +33,13 @@ go_library(
         "program.go",
         "st_ld_operations.go",
     ],
+    cdeps = [
+        "//ebpf_ffi",
+    ],
     cgo = 1,
     importpath = "buzzer/pkg/ebpf/ebpf",
     deps = [
         "//pkg/rand",
-    ],
-    cdeps = [
-        "//ebpf_ffi",
     ],
 )
 
@@ -51,6 +51,6 @@ go_test(
         "program_test.go",
         "st_ld_operations_test.go",
     ],
-    importpath = "buzzer/pkg/ebpf",
     embed = [":ebpf"],
+    importpath = "buzzer/pkg/ebpf",
 )

--- a/pkg/rand/BUILD
+++ b/pkg/rand/BUILD
@@ -22,6 +22,6 @@ package(
 
 go_library(
     name = "rand",
-    importpath = "buzzer/pkg/rand",
     srcs = ["rand.go"],
+    importpath = "buzzer/pkg/rand",
 )

--- a/pkg/strategies/BUILD
+++ b/pkg/strategies/BUILD
@@ -25,7 +25,7 @@ go_library(
     srcs = ["base.go"],
     importpath = "buzzer/pkg/strategies/strategies",
     deps = [
-        "//proto:ebpf_fuzzer_go_proto",
         "//pkg/ebpf",
+        "//proto:ebpf_fuzzer_go_proto",
     ],
 )

--- a/pkg/strategies/base.go
+++ b/pkg/strategies/base.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
-	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 	"buzzer/pkg/ebpf/ebpf"
+	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 )
 
 // GeneratorResult holds the state of generated programs that have been verified.

--- a/pkg/strategies/parse_verifier/BUILD
+++ b/pkg/strategies/parse_verifier/BUILD
@@ -26,15 +26,15 @@ go_library(
         "generator.go",
         "parse_verifier.go",
     ],
-    cgo = 1,
-    importpath = "buzzer/pkg/strategies/parse_verifier/parseverifier",
     cdeps = [
         "//ebpf_ffi",
     ],
+    cgo = 1,
+    importpath = "buzzer/pkg/strategies/parse_verifier/parseverifier",
     deps = [
-        "//proto:ebpf_fuzzer_go_proto",
         "//pkg/ebpf",
         "//pkg/strategies",
         "//pkg/strategies/parse_verifier/oracle",
+        "//proto:ebpf_fuzzer_go_proto",
     ],
 )

--- a/pkg/strategies/parse_verifier/parse_verifier.go
+++ b/pkg/strategies/parse_verifier/parse_verifier.go
@@ -26,10 +26,10 @@ import (
 	"errors"
 	"fmt"
 
-	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 	"buzzer/pkg/ebpf/ebpf"
 	"buzzer/pkg/strategies/parse_verifier/oracle/oracle"
 	"buzzer/pkg/strategies/strategies"
+	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 )
 
 const (
@@ -93,7 +93,7 @@ func (st *StrategyParseVerifierLog) Fuzz(e strategies.ExecutorInterface) error {
 		// Build a new execution request.
 		logMap := gr.Prog.LogMap()
 		logCount := gen.logCount
-		rpr := &fpb.RunProgramRequest {
+		rpr := &fpb.RunProgramRequest{
 			ProgFd:      gr.ProgFD,
 			MapFd:       int64(logMap),
 			MapCount:    logCount,

--- a/pkg/strategies/playground/BUILD
+++ b/pkg/strategies/playground/BUILD
@@ -26,12 +26,12 @@ go_library(
         "generator.go",
         "playground.go",
     ],
-    importpath = "buzzer/pkg/strategies/playground/playground",
-    cgo = 1,
     cdeps = ["//ebpf_ffi"],
+    cgo = 1,
+    importpath = "buzzer/pkg/strategies/playground/playground",
     deps = [
-        "//proto:ebpf_fuzzer_go_proto",
         "//pkg/ebpf",
         "//pkg/strategies",
+        "//proto:ebpf_fuzzer_go_proto",
     ],
 )

--- a/pkg/strategies/playground/playground.go
+++ b/pkg/strategies/playground/playground.go
@@ -24,9 +24,9 @@ import "C"
 import (
 	"fmt"
 
-	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 	"buzzer/pkg/ebpf/ebpf"
 	"buzzer/pkg/strategies/strategies"
+	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 )
 
 const (

--- a/pkg/strategies/pointer_arithmetic/BUILD
+++ b/pkg/strategies/pointer_arithmetic/BUILD
@@ -26,12 +26,12 @@ go_library(
         "generator.go",
         "pointer_arithmetic.go",
     ],
-    cgo = 1,
     cdeps = ["//ebpf_ffi"],
+    cgo = 1,
     importpath = "buzzer/pkg/strategies/pointer_arithmetic/pointerarithmetic",
     deps = [
-        "//proto:ebpf_fuzzer_go_proto",
         "//pkg/ebpf",
         "//pkg/strategies",
+        "//proto:ebpf_fuzzer_go_proto",
     ],
 )

--- a/pkg/strategies/pointer_arithmetic/pointer_arithmetic.go
+++ b/pkg/strategies/pointer_arithmetic/pointer_arithmetic.go
@@ -25,9 +25,9 @@ import "C"
 import (
 	"fmt"
 
-	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 	"buzzer/pkg/ebpf/ebpf"
 	"buzzer/pkg/strategies/strategies"
+	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 )
 
 const (

--- a/pkg/units/BUILD
+++ b/pkg/units/BUILD
@@ -26,18 +26,18 @@ go_library(
         "control_unit.go",
         "executor_unit.go",
     ],
-    cgo = 1,
     cdeps = [
         "//ebpf_ffi",
     ],
+    cgo = 1,
     importpath = "buzzer/pkg/units/units",
     deps = [
-        "//proto:ebpf_fuzzer_go_proto",
         "//pkg/metrics",
         "//pkg/strategies",
         "//pkg/strategies/parse_verifier:parseverifier",
         "//pkg/strategies/playground",
         "//pkg/strategies/pointer_arithmetic:pointerarithmetic",
+        "//proto:ebpf_fuzzer_go_proto",
         "@com_github_golang_protobuf//proto",
     ],
 )

--- a/pkg/units/executor_unit.go
+++ b/pkg/units/executor_unit.go
@@ -29,8 +29,8 @@ import (
 	"fmt"
 	"unsafe"
 
-	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 	"buzzer/pkg/metrics/metrics"
+	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -31,7 +31,7 @@ go_proto_library(
     name = "ebpf_fuzzer_go_proto",
     importpath = "buzzer/proto/ebpf_fuzzer_go_proto",
     protos = [":ebpf_fuzzer_proto"],
-    deps = []
+    deps = [],
 )
 
 cc_proto_library(


### PR DESCRIPTION
This pull request includes the following changes:

1.  Create a github workflow that ensures code is formatted correctly before allowing merge, this uses the following actions:
      -  jidicula/clang-format-action@v4.11.0
      - Jerome1337/gofmt-action@v1.0.5
      - jbajic/buildifier@v1
2. Create a bash script that allows formatting the codebase more easily, as well as instructions on how to install the formatting dependencies (clang-format, gofmt, buildifier)
3. Run the Formatting script in the codebase to resolve formatting issues. 