### PR TITLE
Make sure buzzer always builds on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,11 @@ jobs:
       with:
         path: "~/.cache/bazel"
         key: bazel
-    - run: bazel build //...
-    - run: bazel test //...
+    - run: |
+           sudo apt update
+           sudo apt install clang
+           bazel build //...
+           bazel test //...
+      env:
+       CC:   clang
+       CXX:  clang++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
       with:
         path: "~/.cache/bazel"
         key: bazel
-    - run: |
+    - name: Check Buzzer tests
+      run: |
            sudo apt update
            sudo apt install clang
            bazel build //...

--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 package(
@@ -31,4 +32,9 @@ go_binary(
         "//pkg/metrics",
         "//pkg/units",
     ],
+)
+
+build_test(
+   name = "buzzer_build_test",
+   targets = ["//:buzzer"],
 )

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ that they don't have unexpected behaviour.
 To run the fuzzer follow the next steps
 
 1. Install [bazel](https://bazel.build/).
+1. Install [clang](https://clang.llvm.org/)
+1. Setup the correct CC and CXX env variables
+   ```
+   export CC=clang
+   export CXX=clang++
+   ```
 1. Run 
     ```
     bazel build :buzzer


### PR DESCRIPTION
This patch does the following:

1. Configures github actions to use clang to build buzzer
2. Creates a buld_test target that can be checked at pull request time to make sure buzzer builds correctly
3. Updates the README.md to make it clear buzzer needs clang to build properly.