### PR TITLE
add the stack corruption statregy

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,7 @@ go_binary(
         "-linkmode=external",
         "-extldflags=-static",
     ],
+    static="on",
     deps = [
         "//pkg/metrics",
         "//pkg/units",

--- a/BUILD
+++ b/BUILD
@@ -28,7 +28,7 @@ go_binary(
         "-linkmode=external",
         "-extldflags=-static",
     ],
-    static="on",
+    static = "on",
     deps = [
         "//pkg/metrics",
         "//pkg/units",

--- a/ebpf_ffi/ffi.cc
+++ b/ebpf_ffi/ffi.cc
@@ -132,18 +132,18 @@ struct bpf_result load_bpf_program(void *prog_buff, size_t size,
   struct bpf_insn *insn;
   union bpf_attr attr = {};
 
-    // For the verifier log.
-    unsigned char* log_buf = (unsigned char*)malloc(ebpf_ffi::kLogBuffSize);
-    memset(log_buf, 0, ebpf_ffi::kLogBuffSize);
+  // For the verifier log.
+  unsigned char *log_buf = (unsigned char *)malloc(ebpf_ffi::kLogBuffSize);
+  memset(log_buf, 0, ebpf_ffi::kLogBuffSize);
 
-    insn = (struct bpf_insn *)prog_buff;
-    attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
-    attr.insns = (uint64_t)insn;
-    attr.insn_cnt = (size * sizeof(uint64_t)) / (sizeof(struct bpf_insn));
-    attr.license = (uint64_t) "GPL";
-    attr.log_size = ebpf_ffi::kLogBuffSize;
-    attr.log_buf = (uint64_t)log_buf;
-    attr.log_level = 1;
+  insn = (struct bpf_insn *)prog_buff;
+  attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
+  attr.insns = (uint64_t)insn;
+  attr.insn_cnt = (size * sizeof(uint64_t)) / (sizeof(struct bpf_insn));
+  attr.license = (uint64_t) "GPL";
+  attr.log_size = ebpf_ffi::kLogBuffSize;
+  attr.log_buf = (uint64_t)log_buf;
+  attr.log_level = 3;
 
   struct coverage_data cover;
   memset(&cover, 0, sizeof(struct coverage_data));
@@ -177,9 +177,9 @@ struct bpf_result load_bpf_program(void *prog_buff, size_t size,
     vres.set_is_valid(true);
   }
 
-    free(log_buf);
+  free(log_buf);
 
-    return serialize_proto(vres);
+  return serialize_proto(vres);
 }
 
 int bpf_create_map(enum bpf_map_type map_type, unsigned int key_size,

--- a/pkg/ebpf/generation_utils.go
+++ b/pkg/ebpf/generation_utils.go
@@ -107,6 +107,9 @@ func generateImmAluInstruction(op, insClass uint8, dstReg *Register, prog *Progr
 			maxShift = 32
 		}
 		value = value % maxShift
+		if value < 0 {
+			value *= -1
+		}
 	case AluNeg:
 		value = 0
 	case AluMov:

--- a/pkg/ebpf/jmp_instructions.go
+++ b/pkg/ebpf/jmp_instructions.go
@@ -63,9 +63,7 @@ func (c *JmpImmInstruction) GenerateBytecode() []uint64 {
 
 // GenerateNextInstruction uses the prog generator to create the rest of the tree.
 func (c *JmpImmInstruction) GenerateNextInstruction(prog *Program) {
-	if c.FalseBranchNextInstr != nil {
-		c.FalseBranchNextInstr.GenerateNextInstruction(prog)
-	} else if c.falseBranchGenerator != nil {
+	if c.falseBranchGenerator != nil {
 		nextInstruction, bSize := c.falseBranchGenerator(prog)
 		c.FalseBranchNextInstr = nextInstruction
 		c.FalseBranchSize = bSize

--- a/pkg/strategies/stack_corruption/BUILD
+++ b/pkg/strategies/stack_corruption/BUILD
@@ -21,32 +21,17 @@ package(
 )
 
 go_library(
-    name = "units",
+    name = "stackcorruption",
     srcs = [
-        "control_unit.go",
-        "executor_unit.go",
+        "generator.go",
+        "stack_corruption.go",
     ],
-    cdeps = [
-        "//ebpf_ffi",
-    ],
+    cdeps = ["//ebpf_ffi"],
     cgo = 1,
-    importpath = "buzzer/pkg/units/units",
+    importpath = "buzzer/pkg/strategies/stack_corruption/stackcorruption",
     deps = [
-        "//pkg/metrics",
+        "//pkg/ebpf",
         "//pkg/strategies",
-        "//pkg/strategies/parse_verifier:parseverifier",
-        "//pkg/strategies/playground",
-        "//pkg/strategies/pointer_arithmetic:pointerarithmetic",
-        "//pkg/strategies/stack_corruption:stackcorruption",
         "//proto:ebpf_fuzzer_go_proto",
-        "@com_github_golang_protobuf//proto",
     ],
-)
-
-go_test(
-    name = "units_test",
-    srcs = [
-        "control_unit_test.go",
-    ],
-    embed = [":units"],
 )

--- a/pkg/strategies/stack_corruption/generator.go
+++ b/pkg/strategies/stack_corruption/generator.go
@@ -1,0 +1,148 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackcorruption
+
+import (
+	. "buzzer/pkg/ebpf/ebpf"
+)
+
+// Generator is responsible for constructing the ast for this strategy.
+type Generator struct{
+	instructionCount int
+	magicNumber		int
+	skbOffset		int16
+	mapPtrOffset	int16
+	mapFirstElementOffset int16
+	skbReadOffset   int16
+}
+
+// Generates the first set of instructions of the program.
+func (g *Generator) generateHeader(prog *Program) Instruction {
+	g.instructionCount = int(prog.GetRNG().RandRange(50, 100))
+	g.skbOffset = -8
+	g.mapPtrOffset = -16
+	g.mapFirstElementOffset = -24
+	g.skbReadOffset = -32
+	root, _ := InstructionSequence(
+		// Backup the skb pointer.
+		StDW(RegR10, RegR1, g.skbOffset),
+		LdMapByFd(RegR0, prog.LogMap()),
+		StDW(RegR10, RegR0, g.mapPtrOffset),
+		LdMapElement(RegR0, 0, RegR10, -20),
+		JmpNE(RegR0, 0, 1),
+		Exit(),
+		StDW(RegR10, RegR0, g.mapFirstElementOffset),
+		StDW(RegR10, 0, g.skbReadOffset),
+	)
+
+	for i := prog.MinRegister; i <= prog.MaxRegister; i++ {
+		reg, _ := GetRegisterFromNumber(uint8(i))
+		var instr Instruction
+		if prog.GetRNG().RandRange(1, 10) < 7 {
+			instr, _ = InstructionSequence(
+				LdDW(reg, RegR0, 0),
+				Add64(reg, int32(prog.GetRNG().RandInt())),
+			)
+		} else {
+			instr, _ = InstructionSequence(
+				Mov64(reg, int32(prog.GetRNG().RandInt())),
+			)
+		}
+		prog.MarkRegisterInitialized(i)
+		root.SetNextInstruction(instr)
+	}
+	return root
+}
+
+func (g *Generator) randomAlu(prog *Program) Instruction {
+	return GenerateRandomAluInstruction(prog)
+}
+
+func (g *Generator) randomJmp(prog *Program) Instruction {
+	falseBranchGenerator := func(prog *Program) (Instruction, int16) {
+		operationQuantity := int16(prog.GetRNG().RandRange(1, 10))
+		instructions := []Instruction{}
+		for i := int16(0); i < operationQuantity; i++ {
+			instructions = append(instructions, GenerateRandomAluInstruction(prog))
+		}
+		root, _ := InstructionSequence(instructions...)
+		return root, operationQuantity
+	}
+	return GenerateRandomJmpRegInstruction(prog, g.GenerateNextInstruction, falseBranchGenerator)
+}
+
+func (g *Generator) skbCall(prog *Program) Instruction {
+    source, _ := GetRegisterFromNumber(prog.GetRandomRegister())
+	corruptingSnippet, _ := InstructionSequence(
+		JmpLT(source, 1, 1),
+		Mov64(source, 1),
+		Add64(source, 1),
+		LdDW(RegR1, RegR10, g.skbOffset),
+		CallSkbLoadBytesRelative(RegR1, 0, RegR10, g.skbReadOffset, source, 1),
+		Mov(RegR1, 0x0FFFFFFF),
+	)
+	return corruptingSnippet
+}
+
+// GenerateNextInstruction is responsible for recursively building the ebpf program tree
+func (g *Generator) GenerateNextInstruction(prog *Program) Instruction {
+	g.instructionCount -= 1
+	if (g.instructionCount == 0) {
+		return g.generateProgramFooter(prog)
+	}
+
+	var instr Instruction
+
+	coinToss := prog.GetRNG().RandRange(1, 100)
+
+	if coinToss <= 65 {
+		instr = g.randomJmp(prog)
+	} else {
+		instr = g.randomAlu(prog)
+	}
+
+	instr.GenerateNextInstruction(prog)
+	return instr
+}
+
+// Generate is the main function that builds the ast for this strategy.
+func (g *Generator) Generate(prog *Program) Instruction {
+	header := g.generateHeader(prog)
+	header.SetNextInstruction(g.GenerateNextInstruction(prog))
+	return header
+}
+
+func (g *Generator) generateProgramFooter(p *Program) Instruction {
+	sequence := g.skbCall(p)
+	footer, _ := InstructionSequence(
+		LdDW(RegR0, RegR10, g.mapFirstElementOffset),
+		StDW(RegR0, g.magicNumber, 0),
+		LdDW(RegR0, RegR10, g.mapPtrOffset),
+		LdMapElement(RegR0, 1, RegR10, -36),
+		JmpNE(RegR0, 0, 1),
+		Exit(),
+		StDW(RegR0, g.magicNumber, 0),
+		LdDW(RegR0, RegR10, g.mapPtrOffset),
+		LdMapElement(RegR0, 2, RegR10, -36),
+		JmpNE(RegR0, 0, 1),
+		Exit(),
+		LdDW(RegR1, RegR10, g.skbReadOffset),
+		StDW(RegR0,RegR1, 0),
+		Mov64(RegR0, 0),
+		Exit(),
+	)
+	sequence.SetNextInstruction(footer)
+	return sequence
+}

--- a/pkg/strategies/stack_corruption/generator.go
+++ b/pkg/strategies/stack_corruption/generator.go
@@ -19,13 +19,13 @@ import (
 )
 
 // Generator is responsible for constructing the ast for this strategy.
-type Generator struct{
-	instructionCount int
-	magicNumber		int
-	skbOffset		int16
-	mapPtrOffset	int16
+type Generator struct {
+	instructionCount      int
+	magicNumber           int
+	skbOffset             int16
+	mapPtrOffset          int16
 	mapFirstElementOffset int16
-	skbReadOffset   int16
+	skbReadOffset         int16
 }
 
 // Generates the first set of instructions of the program.
@@ -84,7 +84,7 @@ func (g *Generator) randomJmp(prog *Program) Instruction {
 }
 
 func (g *Generator) skbCall(prog *Program) Instruction {
-    source, _ := GetRegisterFromNumber(prog.GetRandomRegister())
+	source, _ := GetRegisterFromNumber(prog.GetRandomRegister())
 	corruptingSnippet, _ := InstructionSequence(
 		JmpLT(source, 1, 1),
 		Mov64(source, 1),
@@ -99,7 +99,7 @@ func (g *Generator) skbCall(prog *Program) Instruction {
 // GenerateNextInstruction is responsible for recursively building the ebpf program tree
 func (g *Generator) GenerateNextInstruction(prog *Program) Instruction {
 	g.instructionCount -= 1
-	if (g.instructionCount == 0) {
+	if g.instructionCount == 0 {
 		return g.generateProgramFooter(prog)
 	}
 
@@ -139,7 +139,7 @@ func (g *Generator) generateProgramFooter(p *Program) Instruction {
 		JmpNE(RegR0, 0, 1),
 		Exit(),
 		LdDW(RegR1, RegR10, g.skbReadOffset),
-		StDW(RegR0,RegR1, 0),
+		StDW(RegR0, RegR1, 0),
 		Mov64(RegR0, 0),
 		Exit(),
 	)

--- a/pkg/strategies/stack_corruption/stack_corruption.go
+++ b/pkg/strategies/stack_corruption/stack_corruption.go
@@ -1,0 +1,126 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package playground is meant to be a strategy where different functionalities
+// of ebpf can be tested more easily, it's purpose is to experiment more so than
+// fuzz.
+package stackcorruption
+
+//#include <stdlib.h>
+//void close_fd(int fd);
+import "C"
+
+import (
+	"fmt"
+
+	"buzzer/pkg/ebpf/ebpf"
+	"buzzer/pkg/strategies/strategies"
+	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
+)
+
+const (
+	// StrategyName exposes the value of the flag that should be used to
+	// invoke this strategy.
+	StrategyName = "stack_corruption"
+)
+
+// Strategy implements the playground strategy.
+type Strategy struct {
+	mapSize int
+}
+
+// Fuzz implements the main fuzzing logic.
+func (sc *Strategy) Fuzz(e strategies.ExecutorInterface) error {
+	sc.mapSize = 3
+	fmt.Printf("running fuzzing strategy %s\n", StrategyName)
+	count := 0
+	valid := 0
+	invalid := 0
+	bugs := 0
+	for true {
+		fmt.Printf("count: %d, valid: %d, invalid: %d, bugs: %d                                              \r", count, valid, invalid, bugs)
+		count += 1
+	gen := &Generator{
+		magicNumber:0xCAFE,
+	}
+		prog, err := ebpf.New(gen, sc.mapSize, ebpf.RegR6.RegisterNumber(), ebpf.RegR9.RegisterNumber())
+
+		if err != nil {
+			fmt.Println(err)
+			prog.Cleanup()
+			continue
+		}
+		byteCode := prog.GenerateBytecode()
+		res, err := e.ValidateProgram(byteCode)
+		gr := &strategies.GeneratorResult{
+				Prog:         prog,
+				ProgByteCode: byteCode,
+				ProgFD:       res.GetProgramFd(),
+				VerifierLog:  res.GetVerifierLog(),
+			}
+		if err != nil {
+			fmt.Println(err)
+			prog.Cleanup()
+			continue
+		}
+
+		if !res.GetIsValid() {
+			invalid += 1
+			prog.Cleanup()
+			continue
+		}
+
+		valid += 1
+
+		mapDescription := &fpb.ExecutionRequest_MapDescription {
+			MapFd:       int64(prog.LogMap()),
+			MapSize:    uint64(sc.mapSize),
+		}
+		executionRequest := &fpb.ExecutionRequest{
+			ProgFd:      res.GetProgramFd(),
+			Maps:        []*fpb.ExecutionRequest_MapDescription{mapDescription},
+			InputData: []byte{0xff, 0x01, 0x02, 0x03,0x04, 0x05, 0x06, 0x07, 0x08,
+			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		}
+
+		executionResponse, err := e.RunProgram(executionRequest)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		mapElements := executionResponse.GetMapElements()[0].GetElements()
+
+		if mapElements[0] != mapElements[1] {
+			fmt.Println()
+			fmt.Printf("program wrote out of bounds")
+			strategies.SaveExecutionResults(gr)
+			prog.GeneratePoc()
+			bugs += 1
+			prog.Cleanup()
+			continue
+		} else if mapElements[2] == 0 {
+			fmt.Println()
+			fmt.Printf("skb read failed but program was not rejected")
+			strategies.SaveExecutionResults(gr)
+			prog.GeneratePoc()
+			bugs += 1
+			prog.Cleanup()
+			continue
+		}
+
+		prog.Cleanup()
+		C.close_fd(C.int(executionRequest.GetProgFd()))
+	}
+	return nil
+}

--- a/pkg/strategies/stack_corruption/stack_corruption.go
+++ b/pkg/strategies/stack_corruption/stack_corruption.go
@@ -51,9 +51,9 @@ func (sc *Strategy) Fuzz(e strategies.ExecutorInterface) error {
 	for true {
 		fmt.Printf("count: %d, valid: %d, invalid: %d, bugs: %d                                              \r", count, valid, invalid, bugs)
 		count += 1
-	gen := &Generator{
-		magicNumber:0xCAFE,
-	}
+		gen := &Generator{
+			magicNumber: 0xCAFE,
+		}
 		prog, err := ebpf.New(gen, sc.mapSize, ebpf.RegR6.RegisterNumber(), ebpf.RegR9.RegisterNumber())
 
 		if err != nil {
@@ -64,11 +64,11 @@ func (sc *Strategy) Fuzz(e strategies.ExecutorInterface) error {
 		byteCode := prog.GenerateBytecode()
 		res, err := e.ValidateProgram(byteCode)
 		gr := &strategies.GeneratorResult{
-				Prog:         prog,
-				ProgByteCode: byteCode,
-				ProgFD:       res.GetProgramFd(),
-				VerifierLog:  res.GetVerifierLog(),
-			}
+			Prog:         prog,
+			ProgByteCode: byteCode,
+			ProgFD:       res.GetProgramFd(),
+			VerifierLog:  res.GetVerifierLog(),
+		}
 		if err != nil {
 			fmt.Println(err)
 			prog.Cleanup()
@@ -83,15 +83,15 @@ func (sc *Strategy) Fuzz(e strategies.ExecutorInterface) error {
 
 		valid += 1
 
-		mapDescription := &fpb.ExecutionRequest_MapDescription {
-			MapFd:       int64(prog.LogMap()),
-			MapSize:    uint64(sc.mapSize),
+		mapDescription := &fpb.ExecutionRequest_MapDescription{
+			MapFd:   int64(prog.LogMap()),
+			MapSize: uint64(sc.mapSize),
 		}
 		executionRequest := &fpb.ExecutionRequest{
-			ProgFd:      res.GetProgramFd(),
-			Maps:        []*fpb.ExecutionRequest_MapDescription{mapDescription},
-			InputData: []byte{0xff, 0x01, 0x02, 0x03,0x04, 0x05, 0x06, 0x07, 0x08,
-			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			ProgFd: res.GetProgramFd(),
+			Maps:   []*fpb.ExecutionRequest_MapDescription{mapDescription},
+			InputData: []byte{0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
 		}
 
 		executionResponse, err := e.RunProgram(executionRequest)

--- a/pkg/units/control_unit.go
+++ b/pkg/units/control_unit.go
@@ -18,9 +18,10 @@ package units
 import (
 	"fmt"
 
-	spvl "buzzer/pkg/strategies/parse_verifier/parseverifier"
+	"buzzer/pkg/strategies/parse_verifier/parseverifier"
 	"buzzer/pkg/strategies/playground/playground"
-	pa "buzzer/pkg/strategies/pointer_arithmetic/pointerarithmetic"
+	"buzzer/pkg/strategies/pointer_arithmetic/pointerarithmetic"
+	"buzzer/pkg/strategies/stack_corruption/stackcorruption"
 	"buzzer/pkg/strategies/strategies"
 )
 
@@ -108,15 +109,17 @@ func (cu *ControlUnit) Init(executor strategies.ExecutorInterface, runMode, fuzz
 	}
 
 	switch fuzzStrategyFlag {
-	case spvl.StrategyName:
-		cu.strat = &spvl.StrategyParseVerifierLog{}
-	case pa.StrategyName:
-		cu.strat = &pa.Strategy{
+	case parseverifier.StrategyName:
+		cu.strat = &parseverifier.StrategyParseVerifierLog{}
+	case pointerarithmetic.StrategyName:
+		cu.strat = &pointerarithmetic.Strategy{
 			// 60 is an arbitrary number.
 			InstructionCount: 60,
 		}
 	case playground.StrategyName:
 		cu.strat = &playground.Strategy{}
+	case stackcorruption.StrategyName:
+		cu.strat = &stackcorruption.Strategy{}
 	default:
 		return fmt.Errorf("unknown fuzzing strategy: %s", fuzzStrategyFlag)
 	}


### PR DESCRIPTION
The idea was to use the function skb_load_bytes relative to corrupt a function pointer stored in the ebpf stack.

I let it run for almost a week and I found no crashes, sadly, which means that either the strategy needs tuning or we are barking at the wrong tree