### PR TITLE
kPort variable is unused

### DIFF
--- a/ebpf_ffi/ffi.cc
+++ b/ebpf_ffi/ffi.cc
@@ -47,8 +47,6 @@ using ebpf_fuzzer::ValidationResult;
 
 namespace ebpf_ffi {
 
-const int kPort = 1337;
-
 // This constant was determined arbitrarily, the number of 0's has incremented
 // when the size was no longer enough for the verifier logs.
 constexpr size_t kLogBuffSize = 100000000;


### PR DESCRIPTION
Fix annoying warning that kPort is unused:

```
ebpf_ffi/ffi.cc:50:11: warning: unused variable 'kPort' [-Wunused-const-variable]
const int kPort = 1337;
          ^
1 warning generated.
```