### PR TITLE
Make coverage information be available to fuzzing strategies if needed.

### DIFF
--- a/pkg/strategies/base.go
+++ b/pkg/strategies/base.go
@@ -41,6 +41,13 @@ type ExecutorInterface interface {
 	RunProgram(rpr *fpb.ExecutionRequest) (*fpb.ExecutionResult, error)
 }
 
+// CoverageManager objects should be able to provide coverage information
+// to fuzzing strategies.
+type CoverageManager interface {
+	ProcessCoverageAddresses(cov []uint64) ([]string, error)
+	GetCoverageInfoMap() *map[string][]int
+}
+
 // WriteLogFile writes the verifier log `data` to a temporary file.
 func WriteLogFile(data []byte) error {
 	f, err := os.CreateTemp("", "verifier-log-")

--- a/pkg/strategies/parse_verifier/parse_verifier.go
+++ b/pkg/strategies/parse_verifier/parse_verifier.go
@@ -72,7 +72,7 @@ func (st *StrategyParseVerifierLog) generateAndValidateProgram(e strategies.Exec
 }
 
 // Fuzz implements the main fuzzing logic.
-func (st *StrategyParseVerifierLog) Fuzz(e strategies.ExecutorInterface) error {
+func (st *StrategyParseVerifierLog) Fuzz(e strategies.ExecutorInterface, cm strategies.CoverageManager) error {
 	fmt.Printf("running fuzzing strategy %s\n", StrategyName)
 	i := 0
 	for {

--- a/pkg/strategies/playground/playground.go
+++ b/pkg/strategies/playground/playground.go
@@ -41,7 +41,7 @@ type Strategy struct {
 }
 
 // Fuzz implements the main fuzzing logic.
-func (pg *Strategy) Fuzz(e strategies.ExecutorInterface) error {
+func (pg *Strategy) Fuzz(e strategies.ExecutorInterface, cm strategies.CoverageManager) error {
 	// 4 is an arbitrary number.
 	pg.mapSize = 4
 	fmt.Printf("running fuzzing strategy %s\n", StrategyName)

--- a/pkg/strategies/pointer_arithmetic/pointer_arithmetic.go
+++ b/pkg/strategies/pointer_arithmetic/pointer_arithmetic.go
@@ -110,7 +110,7 @@ func (pa *Strategy) executeProgram(e strategies.ExecutorInterface, executionRequ
 }
 
 // Fuzz implements the main fuzzing logic.
-func (pa *Strategy) Fuzz(e strategies.ExecutorInterface) error {
+func (pa *Strategy) Fuzz(e strategies.ExecutorInterface, cm strategies.CoverageManager) error {
 	fmt.Printf("running fuzzing strategy %s\n", StrategyName)
 	i := 0
 	for {

--- a/pkg/strategies/stack_corruption/stack_corruption.go
+++ b/pkg/strategies/stack_corruption/stack_corruption.go
@@ -41,7 +41,7 @@ type Strategy struct {
 }
 
 // Fuzz implements the main fuzzing logic.
-func (sc *Strategy) Fuzz(e strategies.ExecutorInterface) error {
+func (sc *Strategy) Fuzz(e strategies.ExecutorInterface, cm strategies.CoverageManager) error {
 	sc.mapSize = 3
 	fmt.Printf("running fuzzing strategy %s\n", StrategyName)
 	count := 0

--- a/pkg/units/control_unit.go
+++ b/pkg/units/control_unit.go
@@ -31,7 +31,7 @@ type RunMode string
 // StrategyInterface contains all the methods that a fuzzing strategy should
 // implement.
 type StrategyInterface interface {
-	Fuzz(e strategies.ExecutorInterface) error
+	Fuzz(e strategies.ExecutorInterface, cm strategies.CoverageManager) error
 }
 
 // ControlUnit directs the execution of the fuzzer.
@@ -39,11 +39,12 @@ type ControlUnit struct {
 	strat StrategyInterface
 	ex    strategies.ExecutorInterface
 	rm    RunMode
+	cm    strategies.CoverageManager
 	rdy   bool
 }
 
 // Init prepares the control unit to be used.
-func (cu *ControlUnit) Init(executor strategies.ExecutorInterface, runMode, fuzzStrategyFlag string) error {
+func (cu *ControlUnit) Init(executor strategies.ExecutorInterface, coverageManager strategies.CoverageManager, runMode, fuzzStrategyFlag string) error {
 	cu.ex = executor
 
 	switch fuzzStrategyFlag {
@@ -73,5 +74,5 @@ func (cu *ControlUnit) IsReady() bool {
 
 // RunFuzzer kickstars the fuzzer in the mode that was specified at Init time.
 func (cu *ControlUnit) RunFuzzer() error {
-	return cu.strat.Fuzz(cu.ex)
+	return cu.strat.Fuzz(cu.ex, cu.cm)
 }

--- a/pkg/units/coverage_manager.go
+++ b/pkg/units/coverage_manager.go
@@ -13,19 +13,19 @@ type CoverageInfo struct {
 	coveredLines []int
 }
 
-// CoverageManager deals with everything coverage related.
-type CoverageManager struct {
+// CoverageManagerImpl deals with everything coverage related.
+type CoverageManagerImpl struct {
 	coverageLock sync.Mutex
 
 	coverageCache   map[uint64]string
-	coverageInfoMap map[string]*CoverageInfo
+	coverageInfoMap map[string][]int
 
 	addressToLineFunction func(string) (string, error)
 }
 
 // ProcessCoverageAddresses converts raw coverage hex addresses into line
 // numbers and files, it also caches the results.
-func (cm *CoverageManager) ProcessCoverageAddresses(cov []uint64) error {
+func (cm *CoverageManagerImpl) ProcessCoverageAddresses(cov []uint64) ([]string, error) {
 	cm.coverageLock.Lock()
 	defer cm.coverageLock.Unlock()
 
@@ -36,8 +36,19 @@ func (cm *CoverageManager) ProcessCoverageAddresses(cov []uint64) error {
 		}
 	}
 
+	convertAddresses := func() []string {
+		coveredLines := []string{}
+		for _, addr := range cov {
+			line, ok := cm.coverageCache[addr]
+			if ok {
+				coveredLines = append(coveredLines, line)
+			}
+		}
+		return coveredLines
+	}
+
 	if len(unknownAddr) == 0 {
-		return nil
+		return convertAddresses(), nil
 	}
 
 	inputString := ""
@@ -48,7 +59,7 @@ func (cm *CoverageManager) ProcessCoverageAddresses(cov []uint64) error {
 	outString, err := cm.addressToLineFunction(inputString)
 	if err != nil {
 		fmt.Printf("addressToLine error: %v\n", err)
-		return err
+		return nil, err
 	}
 
 	coverage := strings.Split(outString, "\n")
@@ -72,31 +83,36 @@ func (cm *CoverageManager) ProcessCoverageAddresses(cov []uint64) error {
 		fileName := fnAndLn[0]
 		lineNumber, err := strconv.Atoi(fnAndLn[1])
 		if err != nil {
-			return err
+			return nil, err
 		}
 		fullPath := strings.Split(cleanedLine, ":")[0]
 
 		cm.coverageCache[unknownAddr[i]] = fnAndLn[0] + ":" + fnAndLn[1]
 		cm.recordCoverageLine(fileName, fullPath, lineNumber)
 	}
-	return nil
+
+	return convertAddresses(), nil
 }
 
 // RecordCoverageLine records a new observed coverage line and adds it to the
 // corresponding file cache.
-func (cm *CoverageManager) recordCoverageLine(fileName, fullPath string, lineNumber int) {
-	if info, ok := cm.coverageInfoMap[fileName]; !ok {
-		cm.coverageInfoMap[fileName] = &CoverageInfo{
-			fileName:     fileName,
-			fullPath:     fullPath,
-			coveredLines: []int{lineNumber},
-		}
+func (cm *CoverageManagerImpl) recordCoverageLine(fileName, fullPath string, lineNumber int) {
+	if linesForFile, ok := cm.coverageInfoMap[fullPath]; !ok {
+		cm.coverageInfoMap[fullPath] = []int{lineNumber}
 	} else {
-		info.coveredLines = append(info.coveredLines, lineNumber)
+		cm.coverageInfoMap[fullPath] = append(linesForFile, lineNumber)
 	}
 }
 
 // GetCoverageInfoMap returns the coverage info cache.
-func (cm *CoverageManager) GetCoverageInfoMap() *map[string]*CoverageInfo {
+func (cm *CoverageManagerImpl) GetCoverageInfoMap() *map[string][]int {
 	return &cm.coverageInfoMap
+}
+
+func NewCoverageManagerImpl(processingFunction func(string) (string, error)) *CoverageManagerImpl {
+	return &CoverageManagerImpl{
+		coverageCache:         make(map[uint64]string),
+		coverageInfoMap:       make(map[string][]int),
+		addressToLineFunction: processingFunction,
+	}
 }

--- a/pkg/units/metrics_unit.go
+++ b/pkg/units/metrics_unit.go
@@ -18,10 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"sync"
 	"time"
 
+	"buzzer/pkg/strategies/strategies"
 	fpb "buzzer/proto/ebpf_fuzzer_go_proto"
 )
 
@@ -88,7 +88,7 @@ func (mu *Metrics) validationResultProcessingRoutine() {
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		err := mu.metricsCollection.coverageManager.ProcessCoverageAddresses(vres.GetCoverageAddress())
+		_, err := mu.metricsCollection.coverageManager.ProcessCoverageAddresses(vres.GetCoverageAddress())
 		if err != nil {
 			fmt.Printf("%q\n", err)
 		}
@@ -141,22 +141,7 @@ func (mu *Metrics) init() {
 }
 
 // NewMetricsUnit Creates a new Central Metrics Unit.
-func NewMetricsUnit(threshold int, kcovSize uint64, vmLinuxPath, sourceFilesPath, metricsServerAddr string, metricsServerPort uint16) *Metrics {
-	cm := &CoverageManager{
-		coverageCache:   make(map[uint64]string),
-		coverageInfoMap: make(map[string]*CoverageInfo),
-		addressToLineFunction: func(inputString string) (string, error) {
-			cmd := exec.Command("/usr/bin/addr2line", "-e", vmLinuxPath)
-			w, err := cmd.StdinPipe()
-			if err != nil {
-				return "", err
-			}
-			w.Write([]byte(inputString))
-			w.Close()
-			outBytes, err := cmd.Output()
-			return string(outBytes), err
-		},
-	}
+func NewMetricsUnit(threshold int, kcovSize uint64, vmLinuxPath, sourceFilesPath, metricsServerAddr string, metricsServerPort uint16, cm strategies.CoverageManager) *Metrics {
 	mc := &MetricsCollection{
 		coverageManager: cm,
 	}


### PR DESCRIPTION
The raw coverage addresses are already available to fuzzing strategies as part of the validation response proto. With this change now fuzzing strategies can translate these addresses to file and line numbers if they need it.