### PR TITLE
Add a new loader tool that takes as input serialized ebpf protobuf programs [Fix PoC Generation 1/3]

### DIFF
--- a/pkg/ebpf/BUILD
+++ b/pkg/ebpf/BUILD
@@ -40,6 +40,7 @@ go_library(
     deps = [
         "//pkg/rand",
         "//proto:ebpf_go_proto",
+        "@com_github_golang_protobuf//jsonpb",
     ],
 )
 

--- a/pkg/ebpf/encoding_functions.go
+++ b/pkg/ebpf/encoding_functions.go
@@ -28,10 +28,6 @@ type Src interface {
 	pb.Reg | int32 | int
 }
 
-func generatePoc(*pb.Instruction) []string {
-	return []string{}
-}
-
 func encodeAluJmpOpcode(opcode, insClass, source uint8) (uint8, error) {
 	result := uint8(0)
 
@@ -63,9 +59,9 @@ func encodeMemOpcode(op *pb.MemOpcode) (uint8, error) {
 }
 
 // EncodeInstructions transforms the given array to ebpf bytecode.
-func EncodeInstructions(instructions []*pb.Instruction) ([]uint64, error) {
+func EncodeInstructions(program *pb.Program) ([]uint64, error) {
 	result := []uint64{}
-	for _, instruction := range instructions {
+	for _, instruction := range program.Instructions {
 		encoding, err := encodeInstruction(instruction)
 		if err != nil {
 			return nil, err

--- a/pkg/ebpf/poc_generator.go
+++ b/pkg/ebpf/poc_generator.go
@@ -16,21 +16,20 @@ package ebpf
 
 import (
 	pb "buzzer/proto/ebpf_go_proto"
-	jsonpb "github.com/golang/protobuf/jsonpb"
 	"errors"
 	"fmt"
+	jsonpb "github.com/golang/protobuf/jsonpb"
 	"os"
 )
-
 
 // GeneratePoc generates a c program that can be used to reproduce fuzzer
 // test cases.
 func GeneratePoc(program *pb.Program) error {
 	m := &jsonpb.Marshaler{
-		OrigName: true,
-		EnumsAsInts: false,
+		OrigName:     true,
+		EnumsAsInts:  false,
 		EmitDefaults: true,
-		Indent: "   ",
+		Indent:       "   ",
 	}
 	textpbData, err := m.MarshalToString(program)
 	if err != nil {

--- a/pkg/ebpf/poc_generator.go
+++ b/pkg/ebpf/poc_generator.go
@@ -16,282 +16,33 @@ package ebpf
 
 import (
 	pb "buzzer/proto/ebpf_go_proto"
+	jsonpb "github.com/golang/protobuf/jsonpb"
 	"errors"
 	"fmt"
 	"os"
 )
 
-const (
-	aluImmMacroDef = `
-#define BPF_ALU_IMM(OP, DST, IMM, INS_CLASS)				\
-	((struct bpf_insn) {					\
-		.code  = INS_CLASS | BPF_OP(OP) | BPF_K,	\
-		.dst_reg = DST,					\
-		.src_reg = 0,					\
-		.off   = 0,					\
-		.imm   = IMM })
-`
-	aluRegMacroDef = `
-#define BPF_ALU_REG(OP, DST, SRC, INS_CLASS)				\
-	((struct bpf_insn) {					\
-		.code  = INS_CLASS | BPF_OP(OP) | BPF_X,	\
-		.dst_reg = DST,					\
-		.src_reg = SRC,					\
-		.off   = 0,					\
-		.imm   = 0 })
-`
-	exitMacroDef = `
-#define BPF_EXIT_INSN()						\
-	((struct bpf_insn) {					\
-		.code  = BPF_JMP | BPF_EXIT,			\
-		.dst_reg = 0,					\
-		.src_reg = 0,					\
-		.off   = 0,					\
-		.imm   = 0 })
-	`
-	jumpImmMacroDef = `
-#define BPF_JMP_IMM(OP, DST, IMM, OFF, INS_CLASS)				\
-	((struct bpf_insn) {					\
-		.code  = INS_CLASS | BPF_OP(OP) | BPF_K,		\
-		.dst_reg = DST,					\
-		.src_reg = 0,					\
-		.off   = OFF,					\
-		.imm   = IMM })
-`
-	jumpRegMacroDef = `
-#define BPF_JMP_REG(OP, DST, SRC, OFF, INS_CLASS)				\
-	((struct bpf_insn) {					\
-		.code  = INS_CLASS | BPF_OP(OP) | BPF_X,		\
-		.dst_reg = DST,					\
-		.src_reg = SRC,					\
-		.off   = OFF,					\
-		.imm   = 0 })
-`
-	callMacroDef = `
-#define BPF_CALL_FUNC(FUNCTION_NUMBER)						\
-	((struct bpf_insn) {					\
-		.code  = BPF_JMP | BPF_CALL,			\
-		.dst_reg = 0,					\
-		.src_reg = 0,					\
-		.off   = 0,					\
-		.imm   = FUNCTION_NUMBER })
-`
-	loadMapFdDef = `
-#define BPF_LD_MAP_FD(DST, MAP_FD)				\
-	((struct bpf_insn) {					\
-		.code  = BPF_LD | BPF_DW | BPF_IMM,		\
-		.dst_reg = DST,					\
-		.src_reg = 0x01,					\
-		.off   = 0,					\
-		.imm   = (__u32) (MAP_FD) }),			\
-	((struct bpf_insn) {					\
-		.code  = 0, /* zero is reserved opcode */	\
-		.dst_reg = 0,					\
-		.src_reg = 0,					\
-		.off   = 0,					\
-		.imm   = ((__u64) (MAP_FD)) >> 32 })
-`
-	memOperationMacroDef = `
-#define BPF_MEM_OPERATION(INS_CLASS, SIZE, DST, SRC, OFF)			\
-	((struct bpf_insn) {					\
-		.code  = INS_CLASS | BPF_SIZE(SIZE) | BPF_MEM,	\
-		.dst_reg = DST,					\
-		.src_reg = SRC,					\
-		.off   = OFF,					\
-		.imm   = 0 })
-`
-	memImmOperationMacroDef = `
-#define BPF_MEM_IMM_OPERATION(INS_CLASS, SIZE, DST, IMM, OFF)			\
-	((struct bpf_insn) {					\
-		.code  = INS_CLASS | BPF_SIZE(SIZE) | BPF_MEM,	\
-		.dst_reg = DST,					\
-		.src_reg = 0,					\
-		.off   = OFF,					\
-		.imm   = IMM })
-`
-)
-
-const (
-	cHeader = `#include <arpa/inet.h>
-#include <errno.h>
-#include <linux/bpf.h>
-#include <fcntl.h>
-#include <netinet/in.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/syscall.h>
-#include <unistd.h>
-`
-	progLoadFunc = `
-// loads a prog and returns the FD
-int load_prog(void *prog_buff, size_t size) {
-  struct bpf_insn *insn;
-  union bpf_attr attr = {};
-
-  // For the verifier log.
-  int log_size = 100000;
-  unsigned char log_buf[log_size];
-  memset(log_buf, 0, log_size);
-
-  insn = (struct bpf_insn *)prog_buff;
-  attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
-  attr.insns = (uint64_t)insn;
-  attr.insn_cnt = (size * sizeof(uint64_t)) / (sizeof(struct bpf_insn));
-  attr.license = (uint64_t) "GPL";
-  attr.log_size = sizeof(log_buf);
-  attr.log_buf = (uint64_t)log_buf;
-  attr.log_level = 3;
-
-  int program_fd = syscall(SYS_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
-
-  if (program_fd < 0) {
-    // Return why we failed to load the program.
-    for(int i = 0; i < log_size; i++) {
-	    printf("%c", log_buf[i]);
-    }
-    printf("Could not load program: %s\n", strerror(errno));
-    return -1;
-  }
-
-  return program_fd;
-}
-`
-	createMapFunc = `
-int bpf_create_map(unsigned int max_entries) {
-  union bpf_attr attr = {.map_type = BPF_MAP_TYPE_ARRAY,
-                         .key_size = sizeof(uint32_t),
-                         .value_size = sizeof(uint64_t),
-                         .max_entries = max_entries};
-
-  return syscall(SYS_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
-}
-`
-	executeProgramFunc = `
-static int setup_send_sock() {
-  return socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
-}
-
-static int setup_listener_sock() {
-  int sock_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-  if (sock_fd < 0) {
-    return sock_fd;
-  }
-
-  struct sockaddr_in serverAddr;
-  serverAddr.sin_family = AF_INET;
-  serverAddr.sin_port = htons(1337);
-  serverAddr.sin_addr.s_addr = htonl(INADDR_ANY);
-
-  int err = bind(sock_fd, (struct sockaddr *)&serverAddr, sizeof(serverAddr));
-  if (err < 0) return err;
-
-  err = listen(sock_fd, 32);
-  if (err < 0) return err;
-
-  return sock_fd;
-}
-
-int execute_bpf_program(int prog_fd, int map_fd, int map_count, uint64_t* map_contents) {
-  int listener_sock = setup_listener_sock();
-  int send_sock = setup_send_sock();
-
-  if (listener_sock < 0 || send_sock < 0) {
-    printf("Could not open sockets\n");
-    return -1;
-  }
-
-  if (setsockopt(listener_sock, SOL_SOCKET, SO_ATTACH_BPF, &prog_fd,
-                 sizeof(prog_fd)) < 0) {
-    printf("Could not attach bpf program to socket\n");
-    return -1;
-  }
-
-  // trigger execution by connecting to the listener socket
-  struct sockaddr_in serverAddr;
-  serverAddr.sin_family = AF_INET;
-  serverAddr.sin_port = htons(1337);
-  serverAddr.sin_addr.s_addr = htonl(INADDR_ANY);
-
-  // no need to check connect, it will fail anyways
-  connect(send_sock, (struct sockaddr *)&serverAddr, sizeof(serverAddr));
-
-  close(listener_sock);
-  close(send_sock);
-  for (uint64_t key = 0; key < map_count; key++) {
-    uint64_t element = 0;
-    union bpf_attr lookup_map = {.map_fd = (uint32_t)map_fd,
-                                 .key = (uint64_t)&key,
-                                 .value = (uint64_t)&element};
-    int err =
-        syscall(SYS_bpf, BPF_MAP_LOOKUP_ELEM, &lookup_map, sizeof(lookup_map));
-    if (err < 0) {
-      printf("could not lookup map element %ul\n", key);
-      return -1;
-    }
-    map_contents[key] = element;
-  }
-  return 0;
-}
-
-`
-)
 
 // GeneratePoc generates a c program that can be used to reproduce fuzzer
 // test cases.
-func GeneratePoc(instructions []*pb.Instruction, mapSize int) error {
-	macros := []string{}
-	for _, i := range instructions {
-		macros = append(macros, generatePoc(i)...)
+func GeneratePoc(program *pb.Program) error {
+	m := &jsonpb.Marshaler{
+		OrigName: true,
+		EnumsAsInts: false,
+		EmitDefaults: true,
+		Indent: "   ",
 	}
-	pocString := ""
-	for i, m := range macros {
-		if i != len(macros)-1 {
-			pocString += fmt.Sprintf("\t\t\t%s,\n", m)
-		} else {
-			pocString += fmt.Sprintf("\t\t\t%s\n", m)
-		}
+	textpbData, err := m.MarshalToString(program)
+	if err != nil {
+		return err
 	}
-	mainBody := fmt.Sprintf(`int main() {
-		int map_size = %d;
-		int map_fd = bpf_create_map(map_size);
-		uint64_t map_contents[map_size];
-		memset(map_contents, 0, sizeof(map_contents));
-		if (map_fd < 0) {
-			printf("Could not create map\n");
-			return -1;
-		}
-		struct bpf_insn instrs[] = {
-%s
-		};
-		int prog_fd = load_prog(instrs, /*prog_len=*/sizeof(instrs)/sizeof(instrs[0]));
-		if ( prog_fd < 0) {
-			printf("Could not load program\n");
-			return -1;
-		}
-		printf("program loaded successully\n");
-
-		int did_succeed = 0;
-		if (execute_bpf_program(prog_fd, map_fd, map_size, map_contents) < 0) {
-			return -1;
-		}
-		for (int i = 0; i < map_size; i++) {
-			printf("map_element %%llu: %%llu\n", i, map_contents[i]);
-		}
-
-		return 0;
-}`, mapSize, pocString)
-
-	poc := cHeader + aluImmMacroDef + aluRegMacroDef + exitMacroDef + jumpRegMacroDef + jumpImmMacroDef + callMacroDef + loadMapFdDef + memOperationMacroDef + memImmOperationMacroDef + progLoadFunc + createMapFunc + executeProgramFunc + mainBody
-	f, err := os.CreateTemp("", "ebpf-poc-*.c")
+	f, err := os.CreateTemp("", "ebpf-poc-*.json")
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Writing eBPF PoC %q.\n", f.Name())
-	_, err = f.Write([]byte(poc))
+	_, err = f.Write([]byte(textpbData))
 	return errors.Join(err, f.Close())
 
 }

--- a/pkg/strategies/pointer_arithmetic.go
+++ b/pkg/strategies/pointer_arithmetic.go
@@ -114,7 +114,7 @@ func (pa *PointerArithmetic) GenerateProgram(ffi *units.FFI) (*epb.Program, erro
 	}
 	header = append(header, body...)
 	header = append(header, footer...)
-	p := &epb.Program {
+	p := &epb.Program{
 		Instructions: header,
 	}
 	return p, nil

--- a/pkg/strategies/pointer_arithmetic.go
+++ b/pkg/strategies/pointer_arithmetic.go
@@ -24,7 +24,7 @@ type PointerArithmetic struct {
 }
 
 // GenerateProgram should return the instructions to feed the verifier.
-func (pa *PointerArithmetic) GenerateProgram(ffi *units.FFI) ([]*epb.Instruction, error) {
+func (pa *PointerArithmetic) GenerateProgram(ffi *units.FFI) (*epb.Program, error) {
 	pa.programCount += 1
 	fmt.Printf("Generated %d programs, %d were valid               \r", pa.programCount, pa.validProgramCount)
 
@@ -78,8 +78,6 @@ func (pa *PointerArithmetic) GenerateProgram(ffi *units.FFI) ([]*epb.Instruction
 
 		// Load a fd to the map.
 		LdMapByFd(R9, pa.mapFd),
-		JmpNE(R9, 0, 1),
-		Exit(),
 
 		// Begin by writing a value to the map without ptr arithmetic.
 		// 0 here is the index to the map element.
@@ -116,7 +114,10 @@ func (pa *PointerArithmetic) GenerateProgram(ffi *units.FFI) ([]*epb.Instruction
 	}
 	header = append(header, body...)
 	header = append(header, footer...)
-	return header, nil
+	p := &epb.Program {
+		Instructions: header,
+	}
+	return p, nil
 }
 
 // OnVerifyDone process the results from the verifier. Here the strategy

--- a/pkg/units/control.go
+++ b/pkg/units/control.go
@@ -32,7 +32,7 @@ var (
 // implement.
 type Strategy interface {
 	// GenerateProgram should return the instructions to feed the verifier.
-	GenerateProgram(ffi *FFI) ([]*epb.Instruction, error)
+	GenerateProgram(ffi *FFI) (*epb.Program, error)
 
 	// OnVerifyDone process the results from the verifier. Here the strategy
 	// can also tell the fuzzer to continue with execution by returning true
@@ -130,7 +130,7 @@ func (cu *Control) RunFuzzer() error {
 		ok := cu.strat.OnExecuteDone(cu.ffi, exRes)
 		if !ok {
 			fmt.Println("Program produced unexpected results")
-			ebpf.GeneratePoc(prog, 0)
+			ebpf.GeneratePoc(prog)
 		}
 	}
 	return nil

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -34,6 +34,11 @@ go_proto_library(
     deps = [],
 )
 
+cc_proto_library(
+    name = "ebpf_cc_proto",
+    deps = [":ebpf_proto"],
+)
+
 proto_library(
     name = "ffi_proto",
     srcs = ["ffi.proto"],

--- a/proto/ebpf.proto
+++ b/proto/ebpf.proto
@@ -157,3 +157,7 @@ message Instruction {
     Empty empty = 9;
   }
 }
+
+message Program {
+  repeated Instruction instructions = 1;
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+)
+
+cc_binary(
+    name = "loader",
+    srcs = ["loader.cc"],
+    deps = [
+        "//proto:ebpf_cc_proto",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/tools/loader.cc
+++ b/tools/loader.cc
@@ -1,34 +1,36 @@
-#include <iostream>
-#include <fstream>
-#include <string>
 #include <google/protobuf/util/json_util.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
 
 #include "proto/ebpf.pb.h"
 
 int main(int argc, char **argv) {
-    if (argc != 2) {
-      std::cerr << "Usage: " << argv[0] << " path_to_ebpf.json" << std::endl;
-      return -1;
-    }
-    // Read the serialized data from the file (replace with your transfer logic)
-    std::fstream input(argv[1], std::ios::in | std::ios::binary);
-    std::string content((std::istreambuf_iterator<char>(input)),
-                         std::istreambuf_iterator<char>());
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " path_to_ebpf.json" << std::endl;
+    return -1;
+  }
+  // Read the serialized data from the file (replace with your transfer logic)
+  std::fstream input(argv[1], std::ios::in | std::ios::binary);
+  std::string content((std::istreambuf_iterator<char>(input)),
+                      std::istreambuf_iterator<char>());
 
-    // Create a Person message and parse the content
-    ebpf::Program program;
-    google::protobuf::util::JsonParseOptions options;
-    // Adjust options if needed (e.g., ignore unknown fields)
+  // Create a Person message and parse the content
+  ebpf::Program program;
+  google::protobuf::util::JsonParseOptions options;
+  // Adjust options if needed (e.g., ignore unknown fields)
 
-    google::protobuf::util::Status status = google::protobuf::util::JsonStringToMessage(content, &program, options);
+  google::protobuf::util::Status status =
+      google::protobuf::util::JsonStringToMessage(content, &program, options);
 
-    if (!status.ok()) {
-        std::cerr << "Failed to parse JSON: " << status.ToString() << std::endl;
-        return -1;
-    }
+  if (!status.ok()) {
+    std::cerr << "Failed to parse JSON: " << status.ToString() << std::endl;
+    return -1;
+  }
 
-    // TODO: Implement loading the ebpf program.
-    std::cout << "Deserialized Program:" << program.DebugString() << std::endl;
+  // TODO: Implement loading the ebpf program.
+  std::cout << "Deserialized Program:" << program.DebugString() << std::endl;
 
-    return 0;
+  return 0;
 }

--- a/tools/loader.cc
+++ b/tools/loader.cc
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <google/protobuf/util/json_util.h>
+
+#include "proto/ebpf.pb.h"
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+      std::cerr << "Usage: " << argv[0] << " path_to_ebpf.json" << std::endl;
+      return -1;
+    }
+    // Read the serialized data from the file (replace with your transfer logic)
+    std::fstream input(argv[1], std::ios::in | std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(input)),
+                         std::istreambuf_iterator<char>());
+
+    // Create a Person message and parse the content
+    ebpf::Program program;
+    google::protobuf::util::JsonParseOptions options;
+    // Adjust options if needed (e.g., ignore unknown fields)
+
+    google::protobuf::util::Status status = google::protobuf::util::JsonStringToMessage(content, &program, options);
+
+    if (!status.ok()) {
+        std::cerr << "Failed to parse JSON: " << status.ToString() << std::endl;
+        return -1;
+    }
+
+    // TODO: Implement loading the ebpf program.
+    std::cout << "Deserialized Program:" << program.DebugString() << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
This is the initial commit of a new loader tool that allows users to load ebpf programs generated by buzzer into the kernel.

This is meant for testing purposes whenever a suspicious program has been found. We decided to dump a serialized protobuf into disk in buzzer whenever a fuzzing strategy behaved in an unexpected way. The protobuf is serialized to json so users can see what the program looks like and modify it.

For now the tool just parses the json back to pb format. Next PR will implement the actual  loading of the program into the kernel.