### PR TITLE
 Add an ffi layer between c++ and go [Fix PoC Generation 2/3]

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,9 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
 package(
     default_visibility = [
         "//visibility:public",
+    ],
+)
+
+go_binary(
+    name = "ffi",
+    srcs = ["ffi.go"],
+    out = "ffi.so",
+    cgo = 1,
+    importpath = "buzzer/tools/ffi",
+    linkmode = "c-shared",
+    deps = [
+        "//pkg/ebpf",
+        "//proto:ebpf_go_proto",
+        "@com_github_golang_protobuf//jsonpb",
     ],
 )
 
@@ -22,6 +38,7 @@ cc_binary(
     name = "loader",
     srcs = ["loader.cc"],
     deps = [
+        ":ffi.cc",
         "//proto:ebpf_cc_proto",
         "@com_google_protobuf//:protobuf",
     ],

--- a/tools/ffi.go
+++ b/tools/ffi.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"buzzer/pkg/ebpf/ebpf"
+	"fmt"
+	"unsafe"
+
+	epb "buzzer/proto/ebpf_go_proto"
+	jsonpb "github.com/golang/protobuf/jsonpb"
+)
+
+//#include <stdlib.h>
+//#include <string.h>
+import "C"
+
+//export EncodeEBPF
+func EncodeEBPF(serializedProgram unsafe.Pointer, serializedProgramSize C.int, encodingResult, encodingResultSize unsafe.Pointer) {
+
+	// First reconstruct the proto.
+	encodedPb := C.GoBytes(serializedProgram, serializedProgramSize)
+	program := &epb.Program{}
+	err := jsonpb.UnmarshalString(string(encodedPb), program)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Serialize it.
+	encodedProg, err := ebpf.EncodeInstructions(program)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Then do magic to return it to C++
+	// The 8 here is because every bpf instruction is an 8 byte number.
+	cLength := C.ulong(len(encodedProg) * 8)
+
+	// C++ will free the memory.
+	resBuffer := C.malloc(cLength)
+	C.memcpy(resBuffer, unsafe.Pointer(&encodedProg[0]), cLength)
+
+	resultPtr := (**uint64)(encodingResult)
+	*resultPtr = (*uint64)(resBuffer)
+
+	resultSizePtr := (*uint64)(encodingResultSize)
+	*resultSizePtr = uint64(len(encodedProg))
+}
+
+func main() {}


### PR DESCRIPTION
This ffi layer helps reuse the logic of ebpf instruction encoding from buzzer into the loader tool. 