### PR TITLE
Refactor the FFI layer of ebpf to be able to share it with the loader tool [Fix PoC Generation 3/3]

### DIFF
--- a/ebpf_ffi/ffi.cc
+++ b/ebpf_ffi/ffi.cc
@@ -107,60 +107,24 @@ void get_coverage_and_free_resources(struct coverage_data *cstruct,
   munmap(cstruct->coverage_buffer, cstruct->coverage_size * sizeof(uint64_t));
 }
 
-// Retrieves all the elements in a bpf map, returns a serialized MapElements
-// proto message.
-struct bpf_result get_map_elements(int map_fd, uint64_t map_size) {
-  MapElements res;
-  auto elements = res.mutable_elements();
-  for (uint64_t key = 0; key < map_size; key++) {
-    uint64_t element = 0;
-    union bpf_attr lookup_map = {.map_fd = static_cast<uint32_t>(map_fd),
-                                 .key = reinterpret_cast<uint64_t>(&key),
-                                 .value = reinterpret_cast<uint64_t>(&element)};
-    int err =
-        syscall(SYS_bpf, BPF_MAP_LOOKUP_ELEM, &lookup_map, sizeof(lookup_map));
-    if (err < 0) {
-      res.set_error_message(strerror(errno));
-      return serialize_proto(res);
-    }
-    elements->Add(element);
-  }
-  return serialize_proto(res);
-}
-
-struct bpf_result load_bpf_program(void *prog_buff, size_t size,
-                                   int coverage_enabled,
-                                   uint64_t coverage_size) {
-  struct bpf_insn *insn;
-  union bpf_attr attr = {};
-
-  // For the verifier log.
-  unsigned char *log_buf = (unsigned char *)malloc(ebpf_ffi::kLogBuffSize);
-  memset(log_buf, 0, ebpf_ffi::kLogBuffSize);
-
-  insn = (struct bpf_insn *)prog_buff;
-  attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
-  attr.insns = (uint64_t)insn;
-  attr.insn_cnt = (size * sizeof(uint64_t)) / (sizeof(struct bpf_insn));
-  attr.license = (uint64_t) "GPL";
-  attr.log_size = ebpf_ffi::kLogBuffSize;
-  attr.log_buf = (uint64_t)log_buf;
-  attr.log_level = 3;
-
+struct bpf_result ffi_load_bpf_program(void *prog_buff, size_t size,
+                                       int coverage_enabled,
+                                       uint64_t coverage_size) {
+  std::string verifier_log, error_message;
   struct coverage_data cover;
   memset(&cover, 0, sizeof(struct coverage_data));
   cover.fd = -1;
   cover.coverage_size = coverage_size;
   if (coverage_enabled) enable_coverage(&cover);
 
-  int program_fd = syscall(SYS_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
+  int program_fd =
+      load_bpf_program(prog_buff, size, &verifier_log, &error_message);
 
   ValidationResult vres;
   if (coverage_enabled) get_coverage_and_free_resources(&cover, &vres);
 
   // Start building the validation result proto.
-  const char *c_log_buf = reinterpret_cast<const char *>(log_buf);
-  vres.set_verifier_log(std::string(c_log_buf, strlen(c_log_buf)));
+  vres.set_verifier_log(verifier_log);
   vres.set_program_fd(program_fd);
 
   if (cover.fd != -1) {
@@ -173,15 +137,76 @@ struct bpf_result load_bpf_program(void *prog_buff, size_t size,
 
   if (program_fd < 0) {
     // Return why we failed to load the program.
-    vres.set_bpf_error(strerror(errno));
+    vres.set_bpf_error(error_message);
     vres.set_is_valid(false);
   } else {
     vres.set_is_valid(true);
   }
 
-  free(log_buf);
-
   return serialize_proto(vres);
+}
+
+int load_bpf_program(void *prog_buff, size_t prog_size,
+                     std::string *verifier_log, std::string *error) {
+  struct bpf_insn *insn;
+  union bpf_attr attr = {};
+
+  // For the verifier log.
+  unsigned char *log_buf = (unsigned char *)malloc(ebpf_ffi::kLogBuffSize);
+  memset(log_buf, 0, ebpf_ffi::kLogBuffSize);
+
+  insn = (struct bpf_insn *)prog_buff;
+  attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
+  attr.insns = (uint64_t)insn;
+  attr.insn_cnt = (prog_size * sizeof(uint64_t)) / (sizeof(struct bpf_insn));
+  attr.license = (uint64_t) "GPL";
+  attr.log_size = ebpf_ffi::kLogBuffSize;
+  attr.log_buf = (uint64_t)log_buf;
+  attr.log_level = 3;
+
+  int program_fd = syscall(SYS_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
+  if (program_fd < 0) {
+    *error = strerror(errno);
+  }
+
+  *verifier_log =
+      std::string((const char *)log_buf, strlen((const char *)log_buf));
+
+  free(log_buf);
+  return program_fd;
+}
+
+// Retrieves all the elements in a bpf map, returns a serialized MapElements
+// proto message.
+struct bpf_result ffi_get_map_elements(int map_fd, uint64_t map_size) {
+  MapElements res;
+  std::vector<uint64_t> elements;
+  std::string error_message;
+  if (!get_map_elements(map_fd, map_size, &elements, &error_message)) {
+    res.set_error_message(error_message);
+    return serialize_proto(res);
+  }
+  auto proto_elements = res.mutable_elements();
+  proto_elements->Add(elements.begin(), elements.end());
+  return serialize_proto(res);
+}
+
+bool get_map_elements(int map_fd, size_t map_size, std::vector<uint64_t> *res,
+                      std::string *error) {
+  for (uint64_t key = 0; key < map_size; key++) {
+    uint64_t element = 0;
+    union bpf_attr lookup_map = {.map_fd = static_cast<uint32_t>(map_fd),
+                                 .key = reinterpret_cast<uint64_t>(&key),
+                                 .value = reinterpret_cast<uint64_t>(&element)};
+    int err =
+        syscall(SYS_bpf, BPF_MAP_LOOKUP_ELEM, &lookup_map, sizeof(lookup_map));
+    if (err < 0) {
+      *error = strerror(errno);
+      return false;
+    }
+    res->push_back(element);
+  }
+  return true;
 }
 
 int bpf_create_map(enum bpf_map_type map_type, unsigned int key_size,
@@ -194,23 +219,30 @@ int bpf_create_map(enum bpf_map_type map_type, unsigned int key_size,
   return syscall(SYS_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
 }
 
-int create_bpf_map(size_t size) {
+int ffi_create_bpf_map(size_t size) {
   return bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint64_t),
                         size);
 }
 
-struct bpf_result return_error(std::string error_message,
-                               ExecutionResult *result, int *sockets) {
+bool execute_error(std::string *error_message, const char *strerr,
+                   int *sockets) {
   if (sockets != nullptr) {
     close(sockets[0]);
     close(sockets[1]);
   }
+  *error_message = strerr;
+  return false;
+}
+
+struct bpf_result return_error(std::string error_message,
+                               ExecutionResult *result) {
   result->set_did_succeed(false);
   result->set_error_message(error_message);
   return serialize_proto(*result);
 }
 
-struct bpf_result execute_bpf_program(void *serialized_proto, size_t length) {
+struct bpf_result ffi_execute_bpf_program(void *serialized_proto,
+                                          size_t length) {
   ExecutionResult execution_result;
 
   std::string serialized_proto_string(
@@ -218,20 +250,10 @@ struct bpf_result execute_bpf_program(void *serialized_proto, size_t length) {
   ExecutionRequest execution_request;
   if (!execution_request.ParseFromString(serialized_proto_string)) {
     return return_error("Could not parse ExecutionRequest proto",
-                        &execution_result, nullptr);
-  }
-
-  int socks[2] = {};
-  if (socketpair(AF_UNIX, SOCK_DGRAM, 0, socks) != 0) {
-    return return_error(strerror(errno), &execution_result, socks);
+                        &execution_result);
   }
 
   int prog_fd = execution_request.prog_fd();
-  if (setsockopt(socks[0], SOL_SOCKET, SO_ATTACH_BPF, &prog_fd,
-                 sizeof(prog_fd)) != 0) {
-    return return_error(strerror(errno), &execution_result, socks);
-  }
-
   uint8_t *data;
   uint8_t backup_data[4] = {0xAA, 0xAA, 0xAA, 0xAA};
   data = backup_data;
@@ -241,15 +263,35 @@ struct bpf_result execute_bpf_program(void *serialized_proto, size_t length) {
     data_size = execution_request.input_data().length();
   }
 
-  if (write(socks[1], data, data_size) != data_size) {
-    return return_error("Could not write all data to socket", &execution_result,
-                        socks);
+  std::string error_message;
+  if (!execute_bpf_program(prog_fd, data, data_size, &error_message)) {
+    return return_error(error_message, &execution_result);
   }
 
-  close(socks[0]);
-  close(socks[1]);
   execution_result.set_did_succeed(true);
   return serialize_proto(execution_result);
 }
 
-void close_fd(int prog_fd) { close(prog_fd); }
+bool execute_bpf_program(int prog_fd, uint8_t *input, int input_length,
+                         std::string *error_message) {
+  int socks[2] = {};
+  if (socketpair(AF_UNIX, SOCK_DGRAM, 0, socks) != 0) {
+    return execute_error(error_message, strerror(errno), NULL);
+  }
+
+  if (setsockopt(socks[0], SOL_SOCKET, SO_ATTACH_BPF, &prog_fd,
+                 sizeof(prog_fd)) != 0) {
+    return execute_error(error_message, strerror(errno), socks);
+  }
+
+  if (write(socks[1], input, input_length) != input_length) {
+    return execute_error(error_message, "Could not write all data to socket",
+                         socks);
+  }
+
+  close(socks[0]);
+  close(socks[1]);
+  return true;
+}
+
+void ffi_close_fd(int prog_fd) { close(prog_fd); }

--- a/pkg/units/ffi.go
+++ b/pkg/units/ffi.go
@@ -21,11 +21,11 @@ package units
 //  char* serialized_proto;
 //  size_t size;
 //};
-//struct bpf_result load_bpf_program(void* prog_buff, size_t size, int coverage_enabled, unsigned long coverage_size);
-//struct bpf_result execute_bpf_program(void* serialized_proto, size_t length);
-//struct bpf_result get_map_elements(int map_fd, uint64_t map_size);
-//int create_bpf_map(size_t size);
-//void close_fd(int fd);
+//struct bpf_result ffi_load_bpf_program(void* prog_buff, size_t size, int coverage_enabled, unsigned long coverage_size);
+//struct bpf_result ffi_execute_bpf_program(void* serialized_proto, size_t length);
+//struct bpf_result ffi_get_map_elements(int map_fd, uint64_t map_size);
+//int ffi_create_bpf_map(size_t size);
+//void ffi_close_fd(int fd);
 import "C"
 
 import (
@@ -118,7 +118,7 @@ func (e *FFI) ValidateProgram(prog []uint64) (*fpb.ValidationResult, error) {
 	if shouldCollect {
 		cbool = 1
 	}
-	bpfVerifyResult := C.load_bpf_program(unsafe.Pointer(&prog[0]), C.ulong(len(prog)) /*enable_coverage=*/, C.int(cbool) /*coverage_size=*/, C.ulong(coverageSize))
+	bpfVerifyResult := C.ffi_load_bpf_program(unsafe.Pointer(&prog[0]), C.ulong(len(prog)) /*enable_coverage=*/, C.int(cbool) /*coverage_size=*/, C.ulong(coverageSize))
 	res, err := validationProtoFromStruct(&bpfVerifyResult)
 	if err != nil {
 		return nil, err
@@ -133,23 +133,23 @@ func (e *FFI) RunProgram(executionRequest *fpb.ExecutionRequest) (*fpb.Execution
 	if err != nil {
 		return nil, err
 	}
-	res := C.execute_bpf_program(unsafe.Pointer(&serializedProto[0]), C.ulong(len(serializedProto)))
+	res := C.ffi_execute_bpf_program(unsafe.Pointer(&serializedProto[0]), C.ulong(len(serializedProto)))
 	return executionProtoFromStruct(&res)
 }
 
 // CreateMapArray creates an ebpf map of type array and returns its fd.
 // -1 means error.
 func (e *FFI) CreateMapArray(size uint64) int {
-	return int(C.create_bpf_map(C.ulong(size)))
+	return int(C.ffi_create_bpf_map(C.ulong(size)))
 }
 
 // CloseFD closes the provided file descriptor.
 func (e *FFI) CloseFD(fd int) {
-	C.close_fd(C.int(fd))
+	C.ffi_close_fd(C.int(fd))
 }
 
 // GetMapElements fetches the map elements of the given fd.
 func (e *FFI) GetMapElements(fd int, mapSize uint64) (*fpb.MapElements, error) {
-	res := C.get_map_elements(C.int(fd), C.ulong(mapSize))
+	res := C.ffi_get_map_elements(C.int(fd), C.ulong(mapSize))
 	return mapElementsProtoFromStruct(&res)
 }

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -23,10 +23,14 @@ package(
 go_binary(
     name = "ffi",
     srcs = ["ffi.go"],
-    out = "ffi.so",
+    out = "ffi.a",
     cgo = 1,
+    gc_linkopts = [
+        "-extldflags",
+        "-static",
+    ],
     importpath = "buzzer/tools/ffi",
-    linkmode = "c-shared",
+    linkmode = "c-archive",
     deps = [
         "//pkg/ebpf",
         "//proto:ebpf_go_proto",
@@ -37,8 +41,10 @@ go_binary(
 cc_binary(
     name = "loader",
     srcs = ["loader.cc"],
+    features = ["fully_static_link"],
     deps = [
         ":ffi.cc",
+        "//ebpf_ffi",
         "//proto:ebpf_cc_proto",
         "@com_google_protobuf//:protobuf",
     ],

--- a/tools/loader.cc
+++ b/tools/loader.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 
+#include "ebpf_ffi/ffi.h"
 #include "ffi.h"
 #include "proto/ebpf.pb.h"
 
@@ -32,8 +33,35 @@ int main(int argc, char **argv) {
     return -1;
   }
 
-  for (size_t i = 0; i < array_length; i++) {
-    printf("[%lu]: %02lx\n", i, ebpf_instructions[i]);
+  const int map_size = 2;
+  int map_fd = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t),
+                              sizeof(uint64_t), map_size);
+  std::string verifier_log, error_message;
+  int prog_fd = load_bpf_program(ebpf_instructions, array_length, &verifier_log,
+                                 &error_message);
+  std::cout << "Verifier log: " << std::endl << verifier_log;
+
+  if (prog_fd < 0) {
+    std::cerr << "could not load bpf program: " << error_message << std::endl;
+    return -1;
+  }
+
+  uint8_t socket_input[2] = {0xAA, 0xAA};
+  if (!execute_bpf_program(prog_fd, socket_input, sizeof(socket_input),
+                           &error_message)) {
+    std::cerr << "error executing program " << error_message << std::endl;
+    return -1;
+  }
+
+  std::vector<uint64_t> map_elements;
+  if (!get_map_elements(map_fd, map_size, &map_elements, &error_message)) {
+    std::cerr << "Could not get map elements: " << error_message << std::endl;
+    return -1;
+  }
+
+  std::cout << "map elements: " << std::endl;
+  for (auto element : map_elements) {
+    std::cout << "element: " << element << std::endl;
   }
 
   free(ebpf_instructions);


### PR DESCRIPTION
- Shuffle code around in the ebpf loading logic to make it reusable from c++ in other parts of the codebase 
- Finish implementing the loader tool for generated protobuf PoCs from buzzer 