### PR TITLE
Add Playground strategy meant for testing

### DIFF
--- a/pkg/strategies/BUILD
+++ b/pkg/strategies/BUILD
@@ -24,6 +24,7 @@ go_library(
     name = "strategies",
     srcs = [
         "base.go",
+        "playground.go",
         "pointer_arithmetic.go",
     ],
     importpath = "buzzer/pkg/strategies/strategies",

--- a/pkg/strategies/playground.go
+++ b/pkg/strategies/playground.go
@@ -1,0 +1,64 @@
+package strategies
+
+import (
+	. "buzzer/pkg/ebpf/ebpf"
+	"buzzer/pkg/units/units"
+	epb "buzzer/proto/ebpf_go_proto"
+	fpb "buzzer/proto/ffi_go_proto"
+	"fmt"
+)
+
+func NewPlaygroundStrategy() *Playground {
+	return &Playground{isFinished: false}
+}
+
+// Playground is a strategy meant for testing, users can generate Arbitrary
+// programs and then the results of the verifier will be displayed on screen.
+type Playground struct {
+	isFinished bool
+}
+
+// GenerateProgram should return the instructions to feed the verifier.
+func (pg *Playground) GenerateProgram(ffi *units.FFI) (*epb.Program, error) {
+	insn, err := InstructionSequence(
+		Mov64(R0, 0),
+		Exit(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &epb.Program{Instructions: insn}, nil
+}
+
+// OnVerifyDone process the results from the verifier. Here the strategy
+// can also tell the fuzzer to continue with execution by returning true
+// or start over and generate a new program by returning false.
+func (pg *Playground) OnVerifyDone(ffi *units.FFI, verificationResult *fpb.ValidationResult) bool {
+	fmt.Println(verificationResult.VerifierLog)
+	pg.isFinished = true
+	return true
+}
+
+// OnExecuteDone should validate if the program behaved like the
+// verifier expected, if that was not the case it should return false.
+func (pg *Playground) OnExecuteDone(ffi *units.FFI, executionResult *fpb.ExecutionResult) bool {
+	return true
+}
+
+// OnError is used to determine if the fuzzer should continue on errors.
+// true represents continue, false represents halt.
+func (pg *Playground) OnError(e error) bool {
+	fmt.Printf("error %v\n", e)
+	return false
+}
+
+// IsFuzzingDone if true, buzzer will break out of the main fuzzing loop
+// and return normally.
+func (pg *Playground) IsFuzzingDone() bool {
+	return pg.isFinished
+}
+
+// StrategyName is used for strategy selection via runtime flags.
+func (pg *Playground) Name() string {
+	return "playground"
+}

--- a/pkg/strategies/pointer_arithmetic.go
+++ b/pkg/strategies/pointer_arithmetic.go
@@ -14,10 +14,14 @@ var (
 	mapCreationFailed = errors.New("Unable to create map array")
 )
 
+func NewPointerArithmeticStrategy() *PointerArithmetic {
+	return &PointerArithmetic{isFinished: false}
+}
+
 // StrategyInterface contains all the methods that a fuzzing strategy should
 // implement.
 type PointerArithmetic struct {
-	IsFinished        bool
+	isFinished        bool
 	mapFd             int
 	programCount      int
 	validProgramCount int
@@ -155,5 +159,10 @@ func (pa *PointerArithmetic) OnError(e error) bool {
 // IsFuzzingDone if true, buzzer will break out of the main fuzzing loop
 // and return normally.
 func (pa *PointerArithmetic) IsFuzzingDone() bool {
-	return pa.IsFinished
+	return pa.isFinished
+}
+
+// StrategyName is used for strategy selection via runtime flags.
+func (pg *PointerArithmetic) Name() string {
+	return "pointer_arithmetic"
 }

--- a/pkg/units/control.go
+++ b/pkg/units/control.go
@@ -50,6 +50,10 @@ type Strategy interface {
 	// IsFuzzingDone if true, buzzer will break out of the main fuzzing loop
 	// and return normally.
 	IsFuzzingDone() bool
+
+	// Name returns the name of the current strategy to be able
+	// to select it with the command line flag.
+	Name() string
 }
 
 // Control directs the execution of the fuzzer.


### PR DESCRIPTION
Playground strategy can be used to create a sequence of ebpf instructions and then get what the verifier thinks about them.

Also add support for selecting the strategy to run via a command line flag.