### PR TITLE
Introduce RandomMemInstruction generator functions and make Load operations only take src registers

### DIFF
--- a/pkg/ebpf/instruction_generators.go
+++ b/pkg/ebpf/instruction_generators.go
@@ -116,7 +116,7 @@ func RandomOffset(s pb.StLdSize) int16 {
 	}
 
 	if offset > 0 {
-		// Mem offsets from the stackc an only be negative.
+		// Mem offsets from the stack can only be negative.
 		offset = offset * -1
 	}
 

--- a/pkg/ebpf/instruction_generators.go
+++ b/pkg/ebpf/instruction_generators.go
@@ -76,6 +76,43 @@ func RandomJmpInstruction(maxOffset uint64) *pb.Instruction {
 	}
 }
 
+// RandomSize is a helper function to be used in the RandomMemInstruction
+// functions. The result of this function should be one of the recognized
+// operation sizes of ebpf (https://www.kernel.org/doc/html/v5.18/bpf/instruction-set.html#:~:text=The%20size%20modifier%20is%20one%20of%3A)
+func RandomSize() pb.StLdSize {
+	size := rand.SharedRNG.RandInt() % 4
+	// The possible size values of instructions are
+	// W: 0x00
+	// H: 0x08
+	// B: 0x10
+	// DW: 0x18
+	// We can generate these values with a shift to the left of 3 bits.
+	size = size << 3
+	return pb.StLdSize(size)
+}
+
+// Returns a random store or load instruction.
+func RandomMemInstruction() *pb.Instruction {
+	if rand.SharedRNG.OneOf(2) {
+		return RandomStoreInstruction()
+	}
+
+	return RandomLoadInstruction()
+}
+
+func RandomStoreInstruction() *pb.Instruction {
+	/*
+	size := RandomSize()
+	dst := RandomRegister()
+	offset := int16(rand.SharedRNG.randInt())
+	*/
+	return nil
+}
+
+func RandomLoadInstruction() *pb.Instruction {
+	return nil
+}
+
 // RandomJumpOp generates a random jump operator.
 func RandomJumpOp() pb.JmpOperationCode {
 	// https://docs.kernel.org/bpf/instruction-set.html#jump-instructions

--- a/pkg/ebpf/st_ld_instructions.go
+++ b/pkg/ebpf/st_ld_instructions.go
@@ -78,42 +78,22 @@ func StB[T Src](dst pb.Reg, src T, offset int16) *pb.Instruction {
 	return newStoreOperation(pb.StLdSize_StLdSizeB, dst, src, offset)
 }
 
-func newLoadMemOperation[T Src](size pb.StLdSize, dst pb.Reg, src T, offset int16) *pb.Instruction {
-	var srcReg pb.Reg
-	var imm int32
-	var class pb.InsClass
-	switch any(src).(type) {
-	case pb.Reg:
-		srcReg = any(src).(pb.Reg)
-		class = pb.InsClass_InsClassLdx
-		imm = 0
-	case int:
-		srcReg = pb.Reg_R0
-		intImm := any(src).(int)
-		imm = int32(intImm)
-		class = pb.InsClass_InsClassSt
-	default:
-		srcReg = pb.Reg_R0
-		class = pb.InsClass_InsClassLd
-		imm = any(src).(int32)
-	}
-
-	// This if is needed because the underlying interface of
-	// PseudoInstruction is not exported outside of the proto.
+// "Standard" Load operations always take as a source a register.
+func newLoadOperation(size pb.StLdSize, dst pb.Reg, src pb.Reg, offset int16) *pb.Instruction {
 	return &pb.Instruction{
 		Opcode: &pb.Instruction_MemOpcode{
 			MemOpcode: &pb.MemOpcode{
 				Mode:             pb.StLdMode_StLdModeMEM,
 				Size:             size,
-				InstructionClass: class,
+				InstructionClass: pb.InsClass_InsClassLdx,
 			},
 		},
 		DstReg: dst,
-		SrcReg: srcReg,
+		SrcReg: src,
 		// Oh protobuf why don't you have int16 support?, need to cast
 		// this to int32 to make golang happy.
 		Offset:    int32(offset),
-		Immediate: imm,
+		Immediate: UnusedField,
 		PseudoInstruction: &pb.Instruction_Empty{
 			Empty: &pb.Empty{},
 		},
@@ -154,22 +134,22 @@ func newLoadImmOperation(size pb.StLdSize, dst pb.Reg, src pb.Reg, offset int16,
 
 // LdDW Stores 8 byte data from `src` into `dst`
 func LdDW(dst pb.Reg, src pb.Reg, offset int16) *pb.Instruction {
-	return newLoadMemOperation(pb.StLdSize_StLdSizeDW, dst, src, offset)
+	return newLoadOperation(pb.StLdSize_StLdSizeDW, dst, src, offset)
 }
 
 // LdW Stores 4 byte data from `src` into `dst`
 func LdW(dst pb.Reg, src pb.Reg, offset int16) *pb.Instruction {
-	return newLoadMemOperation(pb.StLdSize_StLdSizeW, dst, src, offset)
+	return newLoadOperation(pb.StLdSize_StLdSizeW, dst, src, offset)
 }
 
 // LdH Stores 2 byte (Half word) data from `src` into `dst`
 func LdH(dst pb.Reg, src pb.Reg, offset int16) *pb.Instruction {
-	return newLoadMemOperation(pb.StLdSize_StLdSizeH, dst, src, offset)
+	return newLoadOperation(pb.StLdSize_StLdSizeH, dst, src, offset)
 }
 
 // LdB Stores 1 byte data from `src` into `dst`
 func LdB(dst pb.Reg, src pb.Reg, offset int16) *pb.Instruction {
-	return newLoadMemOperation(pb.StLdSize_StLdSizeB, dst, src, offset)
+	return newLoadOperation(pb.StLdSize_StLdSizeB, dst, src, offset)
 }
 
 func LdMapByFd(dst pb.Reg, fd int) *pb.Instruction {


### PR DESCRIPTION
Introduce helper functions for generating random memory storing/loading operations. Also delete useless code around load operations: under normal circumstances load operations can only take registers as src values.